### PR TITLE
Try going back to original accelerate-based approach for embed.

### DIFF
--- a/doc/compiletime.rst
+++ b/doc/compiletime.rst
@@ -4,17 +4,20 @@
 Speeding up package load time via userimg.jl
 ********
 
-It is possible to embed a binary, compiled version of the ParallelAccelerator
-package into a Julia executable. This has the potential to
-greatly reduce the time it takes for Julia to load ParallelAccelerator.
+When running ParallelAccelerator, you may notice that the first time
+an accelerated function is run, it is in fact quite slow.  This delay
+is caused by the time it takes for Julia to load the
+ParallelAccelerator package itself.  This section presents a
+workaround.
+
+It is possible to embed a binary, compiled version of the
+ParallelAccelerator package into a Julia executable. This has the
+potential to greatly reduce the time it takes for Julia programs that
+use ParallelAccelerator to run.
+
 To use this feature, one needs to have the Julia source code
 and should be able to rebuild Julia.  Hence, users with
 Julia installations using pre-built binaries will not be able to use it.
-
-Note that this approach will speed up the `using ParallelAccelerator`
-statement, but it will merely delay the compilation of most of the
-ParallelAccelerator package until an accelerated function is called.
-This is probably *not* the behavior that most users want.
 
 To use this feature, start the Julia REPL and run the following::
 
@@ -22,9 +25,15 @@ To use this feature, start the Julia REPL and run the following::
     ParallelAccelerator.embed()
 
 
+
+After ``embed`` finishes running, exit the REPL and restart Julia.
+You should now be running a version of Julia in which
+ParallelAccelerator is already included in the Julia system image, and
+therefore the first run of an accelerated function will be much
+faster.
+
 The ``embed`` function tries to embed ParallelAccelerator into the Julia
 version used by the current REPL.
-
 If you want to target a different Julia distribution, you can alternatively use
 the following version of ``embed``::
 

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -19,10 +19,11 @@ The *SELFTIMED* line in the printed output shows the running time,
 while the *SELFPRIMED* line shows the time it takes to compile the
 accelerated code and run it with a small "warm-up" input.
 
-You may notice that the entire time it takes to run the command is
-about 20 or 25 seconds longer than *SELFPRIMED* + *SELFTIMED*.  This
-20- to 25-second delay is the time it takes for the
-ParallelAccelerator package itself to load.
+For the first function you accelerate in a given Julia session, you
+might notice a much longer time being reported for *SELFPRIMED*.  This
+delay (about 20 seconds on an 8-core desktop machine) is the time it
+takes for Julia to load the ParallelAccelerator package itself.  See
+`Speeding up package load time via userimg.jl`_ for a workaround.
 
 Pass the ``--help`` option to see usage information for each example::
 


### PR DESCRIPTION
cc: #56 

This commit tries to go back to the original approach we had for `embed`.  It seems to work; however, I noticed an unpleasant side effect: if I *delete* userimg.jl, and `make clean && make` Julia, I get the following error when trying one of the ParallelAccelerator examples:

```
julia> include("$(homedir())/.julia/v0.4/ParallelAccelerator/examples/laplace-3d/laplace-3d.jl")
ERROR: LoadError: ArgumentError: __UserimgDummyModule__ not found in path
 in skip_deleted at ./dict.jl:773
 in stale_cachefile at loading.jl:441
 in recompile_stale at loading.jl:458
 in _require_from_serialized at loading.jl:83
 in unsafe_getindex at ./array.jl:290
 in ht_keyindex at ./dict.jl:557
 in stale_cachefile at loading.jl:441
 in recompile_stale at loading.jl:458
 in _require_from_serialized at loading.jl:83
 in unsafe_getindex at ./array.jl:290
 in ht_keyindex at ./dict.jl:557
 in find_start_brace at ./REPLCompletions.jl:238
 in done at ./intset.jl:184
 in docm at ./docs/Docs.jl:530
while loading /home/lkuper/.julia/v0.4/ParallelAccelerator/examples/laplace-3d/laplace-3d.jl, in expression starting on line 27
```

I don't know how serious of a problem that is, since the use case of manually deleting userimg.jl isn't too common, but it's pretty weird and I don't know what's happening.  Some kind of package caching/staleness issue?

@DrTodd13 @ninegua can you review this commit and tell me if it's what you had in mind?